### PR TITLE
Update installation and update documentation for QCity

### DIFF
--- a/docs/src/user_guide/installation.md
+++ b/docs/src/user_guide/installation.md
@@ -43,5 +43,4 @@ To update your version:
 4. On the lower right, click on `Upgrade Plugin`. Once upgraded, click on `Close`.
 
 > If you receive an error after the plugin updates, try restarting QGIS.
-> If you still encounter an error, please [email us](mailto:info@north-road.com)
-> for support.
+> If you still encounter an error, please raise an issue on the [QCity GitHub page](https://github.com/north-road/QCity/issues).


### PR DESCRIPTION
Initial documentation for installing and updating QCity. There are a few images missing currently as QCity is not in the QGIS Plugin Repository yet. They will be added later.

Additionally, the support link is to a North Road Consulting e-mail address. @nyalldawson please let me know if this is ok or needs changes.