### PR TITLE
Update metadata description, about and tags

### DIFF
--- a/qcity/metadata.txt
+++ b/qcity/metadata.txt
@@ -12,12 +12,12 @@ name=QCity
 qgisMinimumVersion=3.44
 qgisMaximumVersion=4.99
 supportsQt6=yes
-description=Urban planning tools
+description=Urban development modeling in QGIS
 version=0.5.1
 author=North Road
 email=
 
-about=
+about=QCity is a QGIS plugin that allows for the modeling of constructed, proposed and potential buildings based on approved plans or the urban planning framework. QCity calculates dwelling yield, commercial floorspace yield and parking yield of building levels based the percentage of each floor assigned to different land uses and assumptions provided by the user and then aggregates the dwelling yield, commercial floorspace yield and parking yield for each development site. QCity also aggregates the dwelling yield, commercial floorspace yield and parking yield over a project area incorporating multiple development sites. Modeled buildings can also be visualized in a QGIS 3D map in combination with other spatial data.  
 
 tracker=https://github.com/north-road/QCity/issues
 repository=https://github.com/north-road/QCity
@@ -28,8 +28,8 @@ repository=https://github.com/north-road/QCity
 # Uncomment the following line and add your changelog:
 changelog=changelog
 
-# Tags are comma separated with spaces allowed
-tags=
+Tags are comma separated with spaces allowed
+tags=urban modeling, urban planning, 3D, dwelling yield, commercial yield, parking
 
 homepage=
 category=Vector


### PR DESCRIPTION
Update the metadata.txt file as follows:

1. Update the description to urban development modeling in QGIS. QCity is not strictly limited to urban planners and the new description is more in line with what it does.

2. Update the about section to include a more detailed description of the plugin.

3. Enable tags and add a few tags for QCity.